### PR TITLE
Fix: Adding handling of null responses

### DIFF
--- a/portlandgeneral/responses/energy_tracker/energy_tracker_details.py
+++ b/portlandgeneral/responses/energy_tracker/energy_tracker_details.py
@@ -10,10 +10,19 @@ class EnergyTrackerDetails:
 
         # Format: "2022-01-01T00:00:00-07:00"
         self.last_read_date: str = energy_tracker_details_json.get('lastReadDate')
-        self.bill_to_date_amount: Decimal = Decimal(str(energy_tracker_details_json.get('billToDateAmount')))
-        self.projected_amount: Decimal = Decimal(str(energy_tracker_details_json.get('projectedAmount')))
-        self.min_projected_amount: Decimal = Decimal(str(energy_tracker_details_json.get('minProjectedAmount')))
-        self.max_projected_amount: Decimal = Decimal(str(energy_tracker_details_json.get('maxProjectedAmount')))
+
+        bill_to_date_amount = energy_tracker_details_json.get('billToDateAmount')
+        self.bill_to_date_amount: Decimal = Decimal(str(bill_to_date_amount)) if bill_to_date_amount is not None else None
+
+        projected_amount = energy_tracker_details_json.get('projectedAmount')
+        self.projected_amount: Decimal = Decimal(str(projected_amount)) if projected_amount is not None else None
+
+        min_projected_amount = energy_tracker_details_json.get('minProjectedAmount')
+        self.min_projected_amount: Decimal = Decimal(str(min_projected_amount)) if min_projected_amount is not None else None
+
+        max_projected_amount = energy_tracker_details_json.get('maxProjectedAmount')
+        self.max_projected_amount: Decimal = Decimal(str(max_projected_amount)) if max_projected_amount is not None else None
+
         self.billing_progress: int = energy_tracker_details_json.get('billingProgress')
 
         # Value: EnergyTrackerDetails

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 
 with open('README.md', 'r', encoding='utf-8') as readme:
     long_description = readme.read()


### PR DESCRIPTION
EnergyTrackerDetails was not properly handling cases where response values were null (`None`) when trying to define them as decimals.

There are other areas where the null handling needs to be performed but this covers at least one part.